### PR TITLE
Replace scope: 'openid profile'

### DIFF
--- a/ServiceStack-Auth0-Sample/default.htm
+++ b/ServiceStack-Auth0-Sample/default.htm
@@ -17,7 +17,7 @@
                   callbackURL: 'http://{YOUR_APP_URL}:{YOUR_APP_PORT}/api/auth/auth0'
                 , responseType: 'code'
                 , authParams: {
-                    scope: 'openid profile'
+                    scope: 'openid name email'
                 }
               });
           }


### PR DESCRIPTION
Replaces the ‘openid profile’ scope with ‘openid name email’ which is
the currently recommended one.